### PR TITLE
feat: add Telemetria navigation item to dashboard menu

### DIFF
--- a/src/dashboard/itens-menu.jsx
+++ b/src/dashboard/itens-menu.jsx
@@ -1,10 +1,11 @@
 import { useMemo } from "react"
 import { paths } from "../paths"
 import { SvgIcon } from "@mui/material"
-import { 
+import {
     HomeSmile,
     Users01,
-    Settings04
+    Settings04,
+    BarChartSquare02
 } from "@untitled-ui/icons-react"
 
 export const useSections = () => {
@@ -39,6 +40,15 @@ export const useSections = () => {
                                 path: paths.assinaturasAtivas.list
                             },
                         ]
+                    },
+                    {
+                        title: 'Telemetria',
+                        path: paths.telemetria.index,
+                        icon: (
+                            <SvgIcon fontSize="small">
+                                <BarChartSquare02 />
+                            </SvgIcon>
+                        )
                     },
                     {
                         title: 'Configurações',


### PR DESCRIPTION
## Summary

- A rota `/telemetria` foi adicionada em commits anteriores mas não havia item correspondente no menu lateral
- Adicionado item **Telemetria** no menu de navegação (`itens-menu.jsx`) com ícone `BarChartSquare02`
- A página de Telemetria agora está acessível via navegação, incluindo o monitoramento em tempo real e a documentação da API de eventos (`GET /v1/events`)

## Test plan

- [ ] Verificar que o item "Telemetria" aparece no menu lateral do dashboard
- [ ] Clicar no item e confirmar que navega corretamente para `/telemetria`
- [ ] Confirmar que as abas da página (monitoramento, registros, documentação API) funcionam normalmente

https://claude.ai/code/session_01YYyEhPGShwcMELCJxtk861

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYyEhPGShwcMELCJxtk861)_