### PR TITLE
feat: tela de Eventos com filtros e tabela de dados (/v1/events)

### DIFF
--- a/src/api/events/index.js
+++ b/src/api/events/index.js
@@ -1,0 +1,53 @@
+import axios from 'axios';
+import { isDev, retornaComAtraso } from '../api-defaults';
+
+const EVENTS_BASE_URL = 'https://sales-notify-gkf4c2akhvgsagdt.canadacentral-01.azurewebsites.net';
+
+const httpEventsApi = axios.create({
+    baseURL: EVENTS_BASE_URL,
+    timeout: 20000,
+});
+
+const mockEvents = [
+    {
+        event: 'ai.workflow.generation_succeeded',
+        occurredAt: '2026-05-17T10:00:00.000Z',
+        appVersion: '0.1.8',
+        installId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+        platform: 'linux',
+        payload: { model: 'gpt-4o', provider: 'openai', durationMs: 3240, planType: 'free', quotaRemaining: 7 },
+        savedAt: '2026-05-17T10:00:01.000Z',
+    },
+    {
+        event: 'ai.workflow.generation_failed',
+        occurredAt: '2026-05-17T09:30:00.000Z',
+        appVersion: '0.1.7',
+        installId: 'a1b2c3d4-1234-5678-abcd-ef0123456789',
+        platform: 'win32',
+        payload: { model: 'gpt-4o', provider: 'openai', errorCategory: 'timeout', planType: 'premium' },
+        savedAt: '2026-05-17T09:30:01.000Z',
+    },
+    {
+        event: 'ai.quota.exceeded',
+        occurredAt: '2026-05-16T15:00:00.000Z',
+        appVersion: '0.1.8',
+        installId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+        platform: 'darwin',
+        payload: { planType: 'free', limit: 10, feature: 'generation' },
+        savedAt: '2026-05-16T15:00:01.000Z',
+    },
+];
+
+class EventsApiMock {
+    get(_params) {
+        return retornaComAtraso({ data: mockEvents, total: mockEvents.length, limit: 100, offset: 0, hasMore: false });
+    }
+}
+
+class EventsApi {
+    get(params) {
+        return httpEventsApi.get('/v1/events', { params });
+    }
+}
+
+export const eventsApi = isDev() ? new EventsApiMock() : new EventsApi();

--- a/src/components/telemtria/consulta-eventos.jsx
+++ b/src/components/telemtria/consulta-eventos.jsx
@@ -1,0 +1,367 @@
+import { useState, useCallback, Fragment } from 'react';
+import {
+    Box,
+    Button,
+    Card,
+    CardContent,
+    Chip,
+    CircularProgress,
+    Collapse,
+    FormControl,
+    Grid,
+    IconButton,
+    InputLabel,
+    MenuItem,
+    Select,
+    Stack,
+    SvgIcon,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TablePagination,
+    TableRow,
+    TextField,
+    Typography,
+} from '@mui/material';
+import { ChevronLeftOutlined, ChevronRight } from '@mui/icons-material';
+import { Scrollbar } from 'src/components/scrollbar';
+import { eventsApi } from 'src/api/events';
+
+const EVENT_TYPES = [
+    'ai.workflow.generation_succeeded',
+    'ai.workflow.generation_failed',
+    'ai.quota.exceeded',
+    'ai.workflow.analysis_succeeded',
+    'ai.workflow.analysis_failed',
+    'ai.template.saved',
+    'ai.template.deleted',
+    'ai.session.reset',
+];
+
+const PLATFORMS = ['win32', 'darwin', 'linux'];
+const PROVIDERS = ['openai', 'anthropic', 'ollama'];
+const PLAN_TYPES = ['free', 'premium'];
+
+const EVENT_COLOR = {
+    'ai.workflow.generation_succeeded': 'success',
+    'ai.workflow.analysis_succeeded': 'success',
+    'ai.template.saved': 'info',
+    'ai.workflow.generation_failed': 'error',
+    'ai.workflow.analysis_failed': 'error',
+    'ai.quota.exceeded': 'warning',
+    'ai.template.deleted': 'warning',
+    'ai.session.reset': 'default',
+};
+
+const emptyFilters = {
+    event: '',
+    platform: '',
+    provider: '',
+    planType: '',
+    installId: '',
+    appVersion: '',
+    from: '',
+    to: '',
+};
+
+const PayloadRow = ({ event, payload }) => (
+    <TableRow>
+        <TableCell colSpan={6} sx={{ py: 0 }}>
+            <Collapse in unmountOnExit>
+                <Box sx={{ py: 2, px: 3 }}>
+                    <Typography variant="subtitle2" sx={{ mb: 1 }}>Payload</Typography>
+                    <Box
+                        component="pre"
+                        sx={{
+                            m: 0,
+                            p: 1.5,
+                            bgcolor: 'grey.900',
+                            color: 'grey.100',
+                            borderRadius: 1,
+                            fontSize: '0.78rem',
+                            overflowX: 'auto',
+                            fontFamily: 'monospace',
+                        }}
+                    >
+                        {JSON.stringify({ event, ...payload }, null, 2)}
+                    </Box>
+                </Box>
+            </Collapse>
+        </TableCell>
+    </TableRow>
+);
+
+const EventsTable = ({ items, total, page, rowsPerPage, onPageChange, onRowsPerPageChange }) => {
+    const [expandedRow, setExpandedRow] = useState(null);
+
+    const toggleRow = useCallback((idx) => {
+        setExpandedRow((prev) => (prev === idx ? null : idx));
+    }, []);
+
+    return (
+        <div>
+            <Scrollbar>
+                <Table sx={{ minWidth: 900 }}>
+                    <TableHead>
+                        <TableRow>
+                            <TableCell />
+                            <TableCell>Evento</TableCell>
+                            <TableCell>Ocorrido em</TableCell>
+                            <TableCell>Plataforma</TableCell>
+                            <TableCell>Versão</TableCell>
+                            <TableCell>Install ID</TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {items.length === 0 && (
+                            <TableRow>
+                                <TableCell colSpan={6} align="center" sx={{ py: 4 }}>
+                                    <Typography color="text.secondary">Nenhum evento encontrado</Typography>
+                                </TableCell>
+                            </TableRow>
+                        )}
+                        {items.map((item, idx) => {
+                            const isExpanded = expandedRow === idx;
+                            return (
+                                <Fragment key={idx}>
+                                    <TableRow hover>
+                                        <TableCell padding="checkbox">
+                                            <IconButton size="small" onClick={() => toggleRow(idx)}>
+                                                <SvgIcon fontSize="small">
+                                                    {isExpanded ? <ChevronLeftOutlined /> : <ChevronRight />}
+                                                </SvgIcon>
+                                            </IconButton>
+                                        </TableCell>
+                                        <TableCell>
+                                            <Chip
+                                                label={item.event}
+                                                color={EVENT_COLOR[item.event] || 'default'}
+                                                size="small"
+                                                sx={{ fontFamily: 'monospace', fontSize: '0.72rem' }}
+                                            />
+                                        </TableCell>
+                                        <TableCell>
+                                            <Typography variant="body2">
+                                                {new Date(item.occurredAt).toLocaleString('pt-BR')}
+                                            </Typography>
+                                        </TableCell>
+                                        <TableCell>{item.platform || '—'}</TableCell>
+                                        <TableCell>{item.appVersion || '—'}</TableCell>
+                                        <TableCell>
+                                            <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.78rem' }}>
+                                                {item.installId ? `${item.installId.slice(0, 8)}…` : '—'}
+                                            </Typography>
+                                        </TableCell>
+                                    </TableRow>
+                                    {isExpanded && (
+                                        <PayloadRow event={item.event} payload={item.payload || {}} />
+                                    )}
+                                </Fragment>
+                            );
+                        })}
+                    </TableBody>
+                </Table>
+            </Scrollbar>
+            <TablePagination
+                component="div"
+                count={total}
+                page={page}
+                rowsPerPage={rowsPerPage}
+                onPageChange={onPageChange}
+                onRowsPerPageChange={onRowsPerPageChange}
+                rowsPerPageOptions={[25, 50, 100]}
+                labelRowsPerPage="Por página"
+            />
+        </div>
+    );
+};
+
+export const ConsultaEventos = () => {
+    const [filters, setFilters] = useState(emptyFilters);
+    const [appliedFilters, setAppliedFilters] = useState(emptyFilters);
+    const [events, setEvents] = useState([]);
+    const [total, setTotal] = useState(0);
+    const [page, setPage] = useState(0);
+    const [rowsPerPage, setRowsPerPage] = useState(25);
+    const [loading, setLoading] = useState(false);
+    const [searched, setSearched] = useState(false);
+
+    const buildParams = useCallback((f, p, rpp) => {
+        const params = { limit: rpp, offset: p * rpp };
+        if (f.event) params.event = f.event;
+        if (f.platform) params.platform = f.platform;
+        if (f.provider) params.provider = f.provider;
+        if (f.planType) params.planType = f.planType;
+        if (f.installId) params.installId = f.installId;
+        if (f.appVersion) params.appVersion = f.appVersion;
+        if (f.from) params.from = new Date(f.from).toISOString();
+        if (f.to) params.to = new Date(f.to).toISOString();
+        return params;
+    }, []);
+
+    const fetchEvents = useCallback((f, p, rpp) => {
+        setLoading(true);
+        eventsApi.get(buildParams(f, p, rpp))
+            .then((res) => {
+                setEvents(res.data.data || []);
+                setTotal(res.data.total || 0);
+            })
+            .finally(() => setLoading(false));
+    }, [buildParams]);
+
+    const handleSearch = useCallback(() => {
+        setPage(0);
+        setAppliedFilters(filters);
+        setSearched(true);
+        fetchEvents(filters, 0, rowsPerPage);
+    }, [filters, fetchEvents, rowsPerPage]);
+
+    const handleClear = useCallback(() => {
+        setFilters(emptyFilters);
+        setAppliedFilters(emptyFilters);
+        setEvents([]);
+        setTotal(0);
+        setPage(0);
+        setSearched(false);
+    }, []);
+
+    const handlePageChange = useCallback((_e, newPage) => {
+        setPage(newPage);
+        fetchEvents(appliedFilters, newPage, rowsPerPage);
+    }, [appliedFilters, fetchEvents, rowsPerPage]);
+
+    const handleRowsPerPageChange = useCallback((e) => {
+        const rpp = parseInt(e.target.value, 10);
+        setRowsPerPage(rpp);
+        setPage(0);
+        fetchEvents(appliedFilters, 0, rpp);
+    }, [appliedFilters, fetchEvents]);
+
+    const handleFilterChange = (field) => (e) => {
+        setFilters((prev) => ({ ...prev, [field]: e.target.value }));
+    };
+
+    return (
+        <Stack spacing={3}>
+            <Card variant="outlined">
+                <CardContent>
+                    <Typography variant="subtitle1" sx={{ mb: 2, fontWeight: 700 }}>Filtros</Typography>
+                    <Grid container spacing={2}>
+                        <Grid item xs={12} sm={6} md={3}>
+                            <FormControl fullWidth size="small">
+                                <InputLabel>Tipo de evento</InputLabel>
+                                <Select
+                                    value={filters.event}
+                                    label="Tipo de evento"
+                                    onChange={handleFilterChange('event')}
+                                >
+                                    <MenuItem value=""><em>Todos</em></MenuItem>
+                                    {EVENT_TYPES.map((e) => (
+                                        <MenuItem key={e} value={e} sx={{ fontFamily: 'monospace', fontSize: '0.78rem' }}>{e}</MenuItem>
+                                    ))}
+                                </Select>
+                            </FormControl>
+                        </Grid>
+                        <Grid item xs={12} sm={6} md={3}>
+                            <FormControl fullWidth size="small">
+                                <InputLabel>Plataforma</InputLabel>
+                                <Select value={filters.platform} label="Plataforma" onChange={handleFilterChange('platform')}>
+                                    <MenuItem value=""><em>Todas</em></MenuItem>
+                                    {PLATFORMS.map((p) => <MenuItem key={p} value={p}>{p}</MenuItem>)}
+                                </Select>
+                            </FormControl>
+                        </Grid>
+                        <Grid item xs={12} sm={6} md={3}>
+                            <FormControl fullWidth size="small">
+                                <InputLabel>Provedor</InputLabel>
+                                <Select value={filters.provider} label="Provedor" onChange={handleFilterChange('provider')}>
+                                    <MenuItem value=""><em>Todos</em></MenuItem>
+                                    {PROVIDERS.map((p) => <MenuItem key={p} value={p}>{p}</MenuItem>)}
+                                </Select>
+                            </FormControl>
+                        </Grid>
+                        <Grid item xs={12} sm={6} md={3}>
+                            <FormControl fullWidth size="small">
+                                <InputLabel>Plano</InputLabel>
+                                <Select value={filters.planType} label="Plano" onChange={handleFilterChange('planType')}>
+                                    <MenuItem value=""><em>Todos</em></MenuItem>
+                                    {PLAN_TYPES.map((p) => <MenuItem key={p} value={p}>{p}</MenuItem>)}
+                                </Select>
+                            </FormControl>
+                        </Grid>
+                        <Grid item xs={12} sm={6} md={3}>
+                            <TextField
+                                fullWidth
+                                size="small"
+                                label="Install ID"
+                                value={filters.installId}
+                                onChange={handleFilterChange('installId')}
+                                placeholder="UUID da instalação"
+                            />
+                        </Grid>
+                        <Grid item xs={12} sm={6} md={3}>
+                            <TextField
+                                fullWidth
+                                size="small"
+                                label="Versão do app"
+                                value={filters.appVersion}
+                                onChange={handleFilterChange('appVersion')}
+                                placeholder="ex: 0.1.8"
+                            />
+                        </Grid>
+                        <Grid item xs={12} sm={6} md={3}>
+                            <TextField
+                                fullWidth
+                                size="small"
+                                label="De (data)"
+                                type="datetime-local"
+                                value={filters.from}
+                                onChange={handleFilterChange('from')}
+                                InputLabelProps={{ shrink: true }}
+                            />
+                        </Grid>
+                        <Grid item xs={12} sm={6} md={3}>
+                            <TextField
+                                fullWidth
+                                size="small"
+                                label="Até (data)"
+                                type="datetime-local"
+                                value={filters.to}
+                                onChange={handleFilterChange('to')}
+                                InputLabelProps={{ shrink: true }}
+                            />
+                        </Grid>
+                    </Grid>
+                    <Stack direction="row" spacing={2} sx={{ mt: 2 }}>
+                        <Button variant="contained" onClick={handleSearch} disabled={loading}>
+                            {loading ? <CircularProgress size={18} sx={{ mr: 1 }} /> : null}
+                            Buscar
+                        </Button>
+                        <Button variant="outlined" onClick={handleClear} disabled={loading}>
+                            Limpar
+                        </Button>
+                    </Stack>
+                </CardContent>
+            </Card>
+
+            {searched && (
+                <Card>
+                    <Box sx={{ px: 3, py: 1.5 }}>
+                        <Typography variant="body2" color="text.secondary">
+                            {loading ? 'Carregando…' : `${total} evento(s) encontrado(s)`}
+                        </Typography>
+                    </Box>
+                    <EventsTable
+                        items={events}
+                        total={total}
+                        page={page}
+                        rowsPerPage={rowsPerPage}
+                        onPageChange={handlePageChange}
+                        onRowsPerPageChange={handleRowsPerPageChange}
+                    />
+                </Card>
+            )}
+        </Stack>
+    );
+};

--- a/src/pages/telemetria/index.jsx
+++ b/src/pages/telemetria/index.jsx
@@ -12,10 +12,12 @@ import { useState, useCallback } from 'react';
 import { RealTimeStreaming } from 'src/components/telemtria/real-time-streaming';
 import { ConsultaTelemetria } from 'src/components/telemtria/consulta';
 import { EventsApiDocs } from 'src/components/telemtria/events-api-docs';
+import { ConsultaEventos } from 'src/components/telemtria/consulta-eventos';
 
 const tabs = [
     { label: 'Console', value: 'geral' },
     { label: 'Registros', value: 'registros' },
+    { label: 'Eventos', value: 'eventos' },
     { label: 'Documentação API', value: 'api-docs' },
 ];
 
@@ -67,6 +69,9 @@ const TelemetriaPage = () => {
                     )}
                     {currentTab === 'registros' && (
                         <ConsultaTelemetria/>
+                    )}
+                    {currentTab === 'eventos' && (
+                        <ConsultaEventos/>
                     )}
                     {currentTab === 'api-docs' && (
                         <EventsApiDocs/>


### PR DESCRIPTION
## Resumo

- Cria serviço `eventsApi` (`src/api/events/index.js`) que consome `GET /v1/events` na base URL do serviço de sales-notify
- Cria componente `ConsultaEventos` (`src/components/telemtria/consulta-eventos.jsx`) com filtros completos e tabela paginada
- Adiciona nova aba **Eventos** na página de Telemetria entre "Registros" e "Documentação API"

## Funcionalidades implementadas

- Filtros: tipo de evento, plataforma, provedor, plano, installId, versão do app, data de início e fim
- Tabela com: nome do evento (chip colorido por status), data de ocorrência, plataforma, versão, install ID
- Expansão de linha para exibir o `payload` completo em formato JSON
- Paginação com controle de itens por página (25 / 50 / 100)
- Mock de dados para ambiente de desenvolvimento

## Test plan

- [ ] Abrir `/telemetria` e verificar que a aba "Eventos" aparece
- [ ] Clicar em "Buscar" sem filtros — deve trazer todos os eventos
- [ ] Aplicar filtros individuais e combinados e verificar resultados
- [ ] Expandir uma linha e conferir o payload JSON
- [ ] Testar paginação (próxima página, alterar itens por página)
- [ ] Clicar em "Limpar" e conferir que a tabela some

https://claude.ai/code/session_01KBFJS35mnZEsTScHA7T1Ta

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBFJS35mnZEsTScHA7T1Ta)_