### PR TITLE
feat: add gratuito column and filter to inscricoes screen

### DIFF
--- a/src/api/inscricoes/data.js
+++ b/src/api/inscricoes/data.js
@@ -1,22 +1,27 @@
 export const planosAtivosList = [
     {
         "email": "joao.silva@email.com",
-        "vigenteAte": "2024-12-31"
+        "vigenteAte": "2024-12-31",
+        "gratuito": false
     },
     {
         "email": "maria.santos@email.com",
-        "vigenteAte": "2024-11-30"
+        "vigenteAte": "2024-11-30",
+        "gratuito": true
     },
     {
         "email": "pedro.oliveira@email.com",
-        "vigenteAte": "2024-10-15"
+        "vigenteAte": "2024-10-15",
+        "gratuito": false
     },
     {
         "email": "ana.costa@email.com",
-        "vigenteAte": "2024-12-15"
+        "vigenteAte": "2024-12-15",
+        "gratuito": true
     },
     {
         "email": "carlos.souza@email.com",
-        "vigenteAte": "2024-09-30"
+        "vigenteAte": "2024-09-30",
+        "gratuito": false
     }
 ] 

--- a/src/pages/inscricoes/index.jsx
+++ b/src/pages/inscricoes/index.jsx
@@ -99,7 +99,11 @@ const InscricoesListView = () => {
         return <LinearProgress />
     }
 
-    const filteredItems = items ? (filter === 'Todos' ? items : items.filter(item => statusFromDate(item.vigenteAte) === filter)) : [];
+    const filteredItems = items ? (
+        filter === 'Todos' ? items :
+        filter === 'Gratuito' ? items.filter(item => item.gratuito === true) :
+        items.filter(item => statusFromDate(item.vigenteAte) === filter)
+    ) : [];
 
     return (
         <>
@@ -129,6 +133,7 @@ const InscricoesListView = () => {
                                     <SeverityPill color={filter === 'Ativo' ? 'success' : 'primary'} onClick={() => setFilter('Ativo')} style={{ cursor: 'pointer' }}>Ativo</SeverityPill>
                                     <SeverityPill color={filter === 'Expirando' ? 'warning' : 'primary'} onClick={() => setFilter('Expirando')} style={{ cursor: 'pointer' }}>Expirando</SeverityPill>
                                     <SeverityPill color={filter === 'Expirado' ? 'error' : 'primary'} onClick={() => setFilter('Expirado')} style={{ cursor: 'pointer' }}>Expirado</SeverityPill>
+                                    <SeverityPill color={filter === 'Gratuito' ? 'info' : 'primary'} onClick={() => setFilter('Gratuito')} style={{ cursor: 'pointer' }}>Gratuito</SeverityPill>
                                 </Stack>
                             </Stack>
                             <Stack
@@ -157,6 +162,7 @@ const InscricoesListView = () => {
                                             <TableCell>Email</TableCell>
                                             <TableCell>Vigente Até</TableCell>
                                             <TableCell>Status</TableCell>
+                                            <TableCell>Tipo</TableCell>
                                         </TableRow>
                                     </TableHead>
                                     <TableBody>
@@ -173,6 +179,12 @@ const InscricoesListView = () => {
                                                 </TableCell>
                                                 <TableCell>
                                                     {getStatusBadge(item.vigenteAte)}
+                                                </TableCell>
+                                                <TableCell>
+                                                    {item.gratuito
+                                                        ? <SeverityPill color="info">Gratuito</SeverityPill>
+                                                        : <SeverityPill color="secondary">Pago</SeverityPill>
+                                                    }
                                                 </TableCell>
                                             </TableRow>
                                         ))}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a **Tipo** column na tabela de inscrições exibindo badge `Gratuito` (azul) ou `Pago` (cinza) com base no campo `gratuito` retornado pelo endpoint `/planos`
- Adiciona filtro **Gratuito** nos pills de filtro para exibir somente inscrições gratuitas
- Atualiza dados mock (`data.js`) para incluir o campo `gratuito` nos registros de exemplo

## Test plan

- [ ] Verificar que a coluna "Tipo" aparece na tabela com os badges corretos
- [ ] Clicar no filtro "Gratuito" e confirmar que apenas inscrições com `gratuito: true` são exibidas
- [ ] Confirmar que os demais filtros (Todos, Ativo, Expirando, Expirado) continuam funcionando normalmente

https://claude.ai/code/session_01466ZaWfK9nvpqHqA9KhDoh
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01466ZaWfK9nvpqHqA9KhDoh)_